### PR TITLE
Fix issue with `isValid` (shadowed variables)

### DIFF
--- a/kennitala.js
+++ b/kennitala.js
@@ -6,10 +6,10 @@
 	var kennitala = {};
 
 	kennitala.isValid = function(kennitala) {
-		var isPerson = evaluate(kennitala, isPerson);
-		var isCompany = evaluate(kennitala, isCompany);
+		var person = evaluate(kennitala, isPerson);
+		var company = evaluate(kennitala, isCompany);
 
-		return (isPerson || isCompany);
+		return (person || company);
 	}
 
 	kennitala.isPerson = function (kennitala) {


### PR DESCRIPTION
the isPerson, and isCompany variables were shadowed leading to strange cases such as

```
kennitala.isValid('3333333333') === true
kennitala.isPerson('3333333333') === false
kennitala.isCompany('3333333333') === false
```