### PR TITLE
Fixing the beta publish step to publish on pushes to beta branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish-beta:
-    if: startsWith(github.ref, 'refs/tags/beta-')
+    if: github.ref == 'refs/heads/beta'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Trying to get the github action to publish a beta when pushing to the beta branch