### PR TITLE
V2.0.6 1969 company ID exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Returns an object containing information about the kennitala.
 interface KennitalaInfo {
   kt: string; // The sanitized kennitala
   valid: boolean; // Whether the kennitala is valid
-  type: "person" | "company" | "temporary" | "unknown"; // Type of kennitala
+  type: "person" | "company" | "temporary" | "invalid"; // Type of kennitala
   age?: number; // Age calculated from the birthday (if applicable)
   birthday?: Date; // Date object representing the birthday (if applicable)
   birthdayReadable?: string; // Human-readable date string (if applicable)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kennitala",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kennitala",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kennitala",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Icelandic social security number (kennitölur) utilities for servers and clients",
   "author": "Hermann Björgvin Haraldsson <hermann@hermann.is>",
   "license": "MIT",

--- a/src/generation.ts
+++ b/src/generation.ts
@@ -101,8 +101,19 @@ const generateCompany = (date: Date): string | undefined => {
   return generateKennitala(date, companyDayDelta);
 };
 
+const generateTemporary = (): string => {
+  const digits = "0123456789";
+  let kt = "89"[Math.floor(Math.random())];
+
+  for (let i = 0; i < 9; i++) {
+    kt += digits[Math.floor(Math.random() * digits.length)];
+  }
+
+  return kt;
+};
+
 const personDayDelta = (day: number): number => day;
 
 const companyDayDelta = (day: number): number => day + 40;
 
-export { generatePerson, generateCompany };
+export { generatePerson, generateCompany, generateTemporary };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,20 @@
 // src/index.ts
 
-import { sanitizeInput, isTemporary, getCentury } from "./utils";
+import { sanitizeInput, getCentury } from "./utils";
 import {
-  isValidDate,
-  isPerson,
-  isCompany,
-  isTestPerson,
   evaluate,
   getDefaultOptions,
+  isCompany,
+  isPerson,
+  isTemporary,
+  isTestPerson,
+  isValidDate,
 } from "./validation";
-import { generatePerson, generateCompany } from "./generation";
+import {
+  generatePerson,
+  generateCompany,
+  generateTemporary,
+} from "./generation";
 import { KennitalaInfo, ValidationOptions } from "./types";
 
 export const isValid = (
@@ -81,7 +86,7 @@ export const info = (kennitala: string): KennitalaInfo | undefined => {
     return {
       kt: "",
       valid: false,
-      type: "unknown",
+      type: "invalid",
       birthday: new Date(NaN),
       birthdayReadable: "",
       age: NaN,
@@ -90,12 +95,24 @@ export const info = (kennitala: string): KennitalaInfo | undefined => {
 
   const isPersonType = evaluate(kt, isPerson);
   const isCompanyType = evaluate(kt, isCompany);
+  const isTemporaryType = isTemporary(kt);
+
+  if (isTemporaryType) {
+    return {
+      kt,
+      valid: true,
+      type: "temporary",
+      birthday: new Date(NaN),
+      birthdayReadable: "",
+      age: NaN,
+    };
+  }
 
   if (!isPersonType && !isCompanyType) {
     return {
       kt,
       valid: false,
-      type: "unknown",
+      type: "invalid",
       birthday: new Date(NaN),
       birthdayReadable: "",
       age: NaN,
@@ -142,4 +159,4 @@ export const info = (kennitala: string): KennitalaInfo | undefined => {
   };
 };
 
-export { generatePerson, generateCompany };
+export { generatePerson, generateCompany, generateTemporary };

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@
 export interface KennitalaInfo {
   kt: string;
   valid: boolean;
-  type: "person" | "company" | "unknown";
+  type: "person" | "company" | "temporary" | "invalid";
   birthday: Date;
   birthdayReadable: string;
   age: number;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,9 +11,6 @@ export const sanitizeInput = (kennitala: string): string | undefined => {
     : undefined;
 };
 
-export const isTemporary = (kt: string): boolean =>
-  kt.startsWith("8") || kt.startsWith("9");
-
 export const getCentury = (centuryCode: number): string | null => {
   switch (centuryCode) {
     case 0:

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -22,6 +22,9 @@ const evaluate = (
 };
 
 const isValidDate = (kt: string): boolean => {
+  // Edge case for valid company ID numbers that were created in error in 1969
+  if (["700269", "690269"].includes(kt.substring(0, 6))) return true;
+
   let day = parseInt(kt.substring(0, 2), 10);
   const month = parseInt(kt.substring(2, 4), 10);
   const yearSuffix = kt.substring(4, 6);
@@ -68,6 +71,9 @@ const isCompany = (kt: string): boolean => {
   return day > 40 && day <= 71;
 };
 
+const isTemporary = (kt: string): boolean =>
+  kt.startsWith("8") || kt.startsWith("9");
+
 const getDefaultOptions = (options?: ValidationOptions): ValidationOptions => {
   return {
     allowTestDataset: !!options && options.allowTestDataset === true,
@@ -75,10 +81,11 @@ const getDefaultOptions = (options?: ValidationOptions): ValidationOptions => {
 };
 
 export {
-  isValidDate,
-  isPerson,
-  isCompany,
-  isTestPerson,
   evaluate,
   getDefaultOptions,
+  isCompany,
+  isPerson,
+  isTemporary,
+  isTestPerson,
+  isValidDate,
 };

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -8,6 +8,7 @@ import {
   sanitize,
   formatKennitala,
   generatePerson,
+  generateTemporary,
   info,
 } from "../src/index";
 
@@ -15,41 +16,32 @@ describe("kennitala", () => {
   describe("isCompanyKennitala", () => {
     it("should be able to check if kennitala is of a company", () => {
       expect(isCompanyKennitala("5811131290")).toBe(true);
-      expect(
-        isCompanyKennitala("150484-2359drop table('secretTable')")
-      ).toBe(false);
+      expect(isCompanyKennitala("150484-2359drop table('secretTable')")).toBe(
+        false
+      );
       expect(isCompanyKennitala("1234567890")).toBe(false);
     });
 
     it("should not validate kerfiskennitölur as company kennitala", () => {
-      // Note: Our library does not have makeKerfiskennitala function.
-      // This functionality is not currently supported.
-      // Suggestion: Consider implementing 'kerfiskennitölur' support in the future.
+      expect(isCompanyKennitala(generateTemporary())).toBe(false);
     });
   });
 
   describe("isValid", () => {
     it("should check if a kennitala is valid", () => {
       expect(isValid("1504842359")).toBe(true);
-      // Our library expects a string input. Passing numbers returns false.
-      // Note: Consider adding support for numeric input if desired.
       expect(isValid(1504842359 as unknown as string)).toBe(false);
       expect(isValid("1514842359")).toBe(false);
     });
 
     it("should validate kerfiskennitölur even if they don't follow Mod11 rules", () => {
-      // Note: Our library does not support 'kerfiskennitölur' or bypassing Mod11 rules.
-      // Suggestion: Consider adding support for 'kerfiskennitölur' validation.
+      expect(isValid(generateTemporary())).toBe(true);
     });
   });
 
   describe("sanitize", () => {
     it("should clean kennitala by removing non-digit characters", () => {
-      expect(
-        sanitize("010159-1234")
-      ).toBe("0101591234");
-      // Our library's 'sanitize' function expects a string.
-      // Passing a number returns undefined.
+      expect(sanitize("010159-1234")).toBe("0101591234");
       expect(sanitize("1234567890")).toBe("1234567890");
       expect(sanitize(1234567890 as unknown as string)).toBeUndefined();
     });
@@ -72,9 +64,9 @@ describe("kennitala", () => {
       const ktInfo = info("1504842359");
       expect(ktInfo?.valid).toBe(true);
       expect(ktInfo?.age).toBeDefined();
-      // Since the birth date is 15/04/1984, calculate expected age
+
       const today = new Date();
-      const birthDate = new Date(1984, 3, 15); // Months are zero-based
+      const birthDate = new Date(1984, 3, 15);
       let age = today.getFullYear() - birthDate.getFullYear();
       const m = today.getMonth() - birthDate.getMonth();
       if (m < 0 || (m === 0 && today.getDate() < birthDate.getDate())) {
@@ -84,17 +76,17 @@ describe("kennitala", () => {
     });
 
     it("should return age of company kennitala", () => {
-      // Testing age calculation for company kennitala
       const ktInfo = info("5811131290");
       expect(ktInfo?.valid).toBe(true);
       expect(ktInfo?.type).toBe("company");
       expect(ktInfo?.age).toBeDefined();
-      // Age calculation logic as above
     });
 
     it("should handle age calculation for children younger than 1 year", () => {
-      // Note: Since we cannot set a reference date, we can't accurately test this case.
-      // Suggestion: Update 'info' function to accept a reference date for age calculation.
+      const kt = generatePerson(new Date(), 20);
+      const ktInfo = info(kt!);
+      expect(ktInfo?.valid).toBe(true);
+      expect(ktInfo?.age).toBe(0);
     });
   });
 
@@ -112,7 +104,7 @@ describe("kennitala", () => {
         { date: new Date(1972, 11, 31), kt: "3112722099" },
       ];
       testCases.forEach(({ date, kt }) => {
-        const generatedKt = generatePerson(date, 20); // Fixed increment
+        const generatedKt = generatePerson(date, 20);
         expect(isValid(generatedKt!)).toBe(true);
         expect(generatedKt).toBe(kt);
       });
@@ -125,10 +117,6 @@ describe("kennitala", () => {
   });
 
   describe("isValidDate", () => {
-    // Note: Our library does not have an 'isValidDate' function.
-    // Suggestion: Consider implementing 'isValidDate' to check if the kennitala has a valid birth date.
-    // For now, we can infer validity from 'info' function's 'birthday' property.
-
     it("should verify if kennitala has a valid birthdate", () => {
       const ktInfo1 = info("3106162180");
       expect(ktInfo1?.valid).toBe(false);
@@ -137,7 +125,6 @@ describe("kennitala", () => {
       expect(ktInfo2?.valid).toBe(true);
       expect(ktInfo2?.birthday?.toISOString().split("T")[0]).toBe("1984-04-15");
 
-      // const ktInfo3 = info("2902121239");
       const ktInfo3 = info(generatePerson(new Date(2012, 1, 29), 20) || "");
       expect(ktInfo3?.valid).toBe(true);
       expect(ktInfo3?.birthday?.toISOString().split("T")[0]).toBe("2012-02-29");
@@ -155,19 +142,14 @@ describe("kennitala", () => {
   });
 
   describe("Exception Handling for Year 1969", () => {
-    // Note: Our library does not make exceptions for illegal kennitölur from 1969.
-    // Suggestion: Consider implementing exception handling for historical kennitölur as per Icelandic registry nuances.
-    // For now, these tests will reflect the current behavior.
-
-    it("should not validate illegal kennitölur from the year 1969", () => {
-      expect(isValid("6902691111")).toBe(false);
-      expect(isValid("7002691111")).toBe(false);
-      expect(isValid("7102691111")).toBe(false);
-      expect(isValid("7202691111")).toBe(false);
+    it("should validate illegal company kennitölur from the year 1969", () => {
+      expect(isValid("7002694509")).toBe(true);
+      expect(isValid("7002691249")).toBe(true);
+      expect(isValid("6902696279")).toBe(true);
+      expect(isValid("6902690829")).toBe(true);
     });
   });
 
-  // Existing tests from your library
   describe("isPersonKennitala", () => {
     it("should validate known valid personal kennitala of various formats", () => {
       expect(isPersonKennitala("3108962099")).toBe(true);
@@ -259,19 +241,11 @@ describe("kennitala", () => {
 
   describe("Leap Year Edge Cases", () => {
     it("should validate kennitala on February 29th of a leap year", () => {
-      const kt = generatePerson(new Date(Date.UTC(2000, 1, 29)), 20); // Fixed increment
+      const kt = generatePerson(new Date(Date.UTC(2000, 1, 29)), 20);
       expect(kt).toBeDefined();
       expect(isValid(kt!)).toBe(true);
       const ktInfo = info(kt!);
       expect(ktInfo?.birthday?.toISOString().split("T")[0]).toBe("2000-02-29");
-    });
-
-    it("should adjust date and generate kennitala for March 1st when provided February 29th of a non-leap year", () => {
-      const date = new Date(Date.UTC(2001, 1, 29)); // Adjusts to March 1st, 2001
-      const kt = generatePerson(date, 20);
-      expect(kt).toBeDefined();
-      const ktInfo = info(kt!);
-      expect(ktInfo?.birthday?.toISOString().split("T")[0]).toBe("2001-03-01");
     });
   });
 
@@ -298,7 +272,7 @@ describe("kennitala", () => {
       expect(Math.floor(ktInfo!.age!)).toBe(30);
     });
 
-    it("should calculate age correctly when birthday has not occurred yet this year", () => {
+    it("should calculate age correctly when birthday is tomorrow", () => {
       const today = new Date();
       const birthYear = today.getUTCFullYear() - 30;
       const birthDate = new Date(


### PR DESCRIPTION
Adds exceptions for companies from 1969 which have an ID with illegal dates for 29th and 30th of February 1969