### PR TITLE
Updated API to be more compatible with V1. Removed undefined return from info function

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ const sanitizedKennitala = sanitize("310896-2099");
 ```javascript
 import {
   isValid,
-  isPersonKennitala,
-  isCompanyKennitala,
+  isPerson,
+  isCompany,
   formatKennitala,
   info,
   generatePerson,
@@ -62,15 +62,15 @@ const kennitalaInfo = info('3108962099');
 }
 
 // Check if a kennitala is valid for a person (returns false for companies)
-isPersonKennitala('3108962099');            // returns true
-isPersonKennitala('601010-0890');           // returns false (invalid date)
-isPersonKennitala(3108962099);              // returns false (invalid input type)
-isPersonKennitala('31^_^08!!96LOL20T_T99'); // returns false (invalid format)
+isPerson('3108962099');            // returns true
+isPerson('601010-0890');           // returns false (invalid date)
+isPerson(3108962099);              // returns false (invalid input type)
+isPerson('31^_^08!!96LOL20T_T99'); // returns false (invalid format)
 
 // Check if a kennitala is valid for a company (returns false for persons)
-isCompanyKennitala('6010100890');  // returns true
-isCompanyKennitala('601010-0890'); // returns true
-isCompanyKennitala('3108962099');  // returns false
+isCompany('6010100890');  // returns true
+isCompany('601010-0890'); // returns true
+isCompany('3108962099');  // returns false
 
 // Format a kennitala by adding a traditional '-' spacer
 formatKennitala('3108962099');       // returns '310896-2099'
@@ -93,7 +93,7 @@ Checks if the kennitala checksum is correct for either a person or company. Non-
 
 - **Returns:** `true` if the kennitala is valid, `false` otherwise.
 
-#### `isPersonKennitala(kennitala: string, options?: { allowTestKennitala?: boolean }): boolean`
+#### `isPerson(kennitala: string, options?: { allowTestKennitala?: boolean }): boolean`
 
 Checks if the kennitala is valid for a person. The day of birth must be between 1-31. Non-digit characters are removed before validation.
 
@@ -104,7 +104,7 @@ Checks if the kennitala is valid for a person. The day of birth must be between 
 
 - **Returns:** `true` if the kennitala is valid for a person, `false` otherwise.
 
-#### `isCompanyKennitala(kennitala: string): boolean`
+#### `isCompany(kennitala: string): boolean`
 
 Checks if the kennitala is valid for a company. The day of birth must be between 41-71. Non-digit characters are removed before validation.
 
@@ -114,7 +114,7 @@ Checks if the kennitala is valid for a company. The day of birth must be between
 
 - **Returns:** `true` if the kennitala is valid for a company, `false` otherwise.
 
-#### `isTemporaryKennitala(kennitala: string): boolean`
+#### `isTemporary(kennitala: string): boolean`
 
 Checks if the kennitala is a valid temporary ID.
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Sanitizes the input by removing all non-digit characters.
 
 #### `formatKennitala(kennitala: string, spacer?: boolean): string`
 
-Formats the kennitala by adding a `-` spacer between the 6th and 7th digits.
+Formats the kennitala by adding a `-` spacer between the 6th and 7th digits. Does not validate the input.
 
 - **Parameters:**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kennitala",
-  "version": "2.0.6",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kennitala",
-      "version": "2.0.6",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kennitala",
-  "version": "2.0.6",
+  "version": "3.0.0",
   "description": "Icelandic social security number (kennitölur) utilities for servers and clients",
   "author": "Hermann Björgvin Haraldsson <hermann@hermann.is>",
   "license": "MIT",

--- a/src/generation.ts
+++ b/src/generation.ts
@@ -92,7 +92,7 @@ const generateKennitala = (
 
 const generatePerson = (
   date: Date,
-  startingIncrement?: number
+  startingIncrement = 20
 ): string | undefined => {
   return generateKennitala(date, personDayDelta, startingIncrement);
 };

--- a/src/generation.ts
+++ b/src/generation.ts
@@ -1,7 +1,6 @@
 // src/generation.ts
 
-import { MAGIC_NUMBERS, padZero } from "./utils";
-import { isPerson } from "./validation";
+import { calculateChecksumRemainder, padZero } from "./utils";
 
 const generateKennitala = (
   date: Date,
@@ -18,28 +17,15 @@ const generateKennitala = (
   let kt = `${padZero(day)}${padZero(month)}${yearSuffix}`;
 
   const randomAndChecksum = (kt: string): string => {
-    let digit7 = Math.floor(Math.random() * 10);
+    const digit7 = Math.floor(Math.random() * 10);
     const digit8 = Math.floor(Math.random() * 10);
 
-    if (isPerson(kt)) {
-      digit7 = Math.floor(Math.random() * 8 + 2);
-    }
-
     const tempKt = kt + digit7.toString() + digit8.toString();
+    const remainder = calculateChecksumRemainder(tempKt);
 
-    let sum = 0;
-    for (let i = 0; i < 8; i++) {
-      sum += parseInt(tempKt[i], 10) * MAGIC_NUMBERS[i];
-    }
-
-    let remainder = 11 - (sum % 11);
-    remainder = remainder === 11 ? 0 : remainder;
-
-    if (remainder === 10) {
-      return randomAndChecksum(kt);
-    } else {
-      return `${digit7}${digit8}${remainder}`;
-    }
+    return remainder === null
+      ? randomAndChecksum(kt)
+      : `${digit7}${digit8}${remainder}`;
   };
 
   const incrementingChecksum = (
@@ -54,16 +40,9 @@ const generateKennitala = (
       const digit8 = digits[1];
 
       const tempKt = kt + digit7 + digit8;
+      const remainder = calculateChecksumRemainder(tempKt);
 
-      let sum = 0;
-      for (let i = 0; i < 8; i++) {
-        sum += parseInt(tempKt[i], 10) * MAGIC_NUMBERS[i];
-      }
-
-      let remainder = 11 - (sum % 11);
-      remainder = remainder === 11 ? 0 : remainder;
-
-      if (remainder === 10) {
+      if (remainder === null) {
         inc++;
         continue;
       } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ export const sanitize = (kennitala: string): string | undefined =>
 export const format = (kennitala: string, spacer: boolean = true): string => {
   const kt = kennitala.replace(/\D+/g, "");
 
-  return `${kt.slice(0, 6)}${spacer && kt.length > 5 ? "-" : ""}${kt.slice(6)}`;
+  return `${kt.slice(0, 6)}${spacer && kt.length > 6 ? "-" : ""}${kt.slice(6)}`;
 };
 
 export const info = (

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,10 +71,7 @@ export const isTemporary = (kennitala: string): boolean => {
 export const sanitize = (kennitala: string): string | undefined =>
   sanitizeInput(kennitala);
 
-export const formatKennitala = (
-  kennitala: string,
-  spacer: boolean = true
-): string => {
+export const format = (kennitala: string, spacer: boolean = true): string => {
   const kt = kennitala.replace(/\D+/g, "");
 
   return `${kt.slice(0, 6)}${spacer && kt.length > 5 ? "-" : ""}${kt.slice(6)}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,10 +74,10 @@ export const sanitize = (kennitala: string): string | undefined =>
 export const formatKennitala = (
   kennitala: string,
   spacer: boolean = true
-): string | undefined => {
-  const kt = sanitizeInput(kennitala);
-  if (!kt) return undefined;
-  return `${kt.slice(0, 6)}${spacer ? "-" : ""}${kt.slice(6)}`;
+): string => {
+  const kt = kennitala.replace(/\D+/g, "");
+
+  return `${kt.slice(0, 6)}${spacer && kt.length > 5 ? "-" : ""}${kt.slice(6)}`;
 };
 
 export const info = (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 // src/utils.ts
 
-export const MAGIC_NUMBERS = [3, 2, 7, 6, 5, 4, 3, 2, 0, 0];
+const MAGIC_NUMBERS = [3, 2, 7, 6, 5, 4, 3, 2, 0, 0];
 
 export const padZero = (num: number): string =>
   num < 10 ? `0${num}` : `${num}`;
@@ -24,16 +24,12 @@ export const getCentury = (centuryCode: number): string | null => {
   }
 };
 
-export const calculateCheckDigit = (kt: string): number | null => {
-  const sum = kt
-    .slice(0, 8)
-    .split("")
-    .reduce(
-      (acc, curr, idx) => acc + parseInt(curr, 10) * MAGIC_NUMBERS[idx],
-      0
-    );
+export const calculateChecksumRemainder = (kt: string): number | null => {
+  let sum = 0;
+  for (let i = 0; i < 8; i++) {
+    sum += parseInt(kt[i], 10) * MAGIC_NUMBERS[i];
+  }
+
   const remainder = 11 - (sum % 11);
-  if (remainder === 11) return 0;
-  if (remainder === 10) return null;
-  return remainder;
+  return remainder === 10 ? null : remainder === 11 ? 0 : remainder;
 };

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -22,6 +22,9 @@ const evaluate = (
 };
 
 const isValidDate = (kt: string): boolean => {
+  // Ensure every KT is from 19th, 20th or 21st century
+  if (!["0", "9", "8"].includes(kt.substring(9, 10))) return false;
+
   // Edge case for valid company ID numbers that were created in error in 1969
   if (["700269", "690269"].includes(kt.substring(0, 6))) return true;
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,6 +1,6 @@
 // src/validation.ts
 
-import { MAGIC_NUMBERS, getCentury } from "./utils";
+import { calculateChecksumRemainder, getCentury } from "./utils";
 import { ValidationOptions } from "./types";
 
 const evaluate = (
@@ -11,14 +11,10 @@ const evaluate = (
     return false;
   }
 
-  const sum = kt
-    .split("")
-    .reduce((prev, curr, i) => prev + parseInt(curr, 10) * MAGIC_NUMBERS[i], 0);
-
-  const remainder = 11 - (sum % 11);
+  const remainder = calculateChecksumRemainder(kt);
   const checkDigit = parseInt(kt.charAt(8), 10);
 
-  return (remainder === 11 && checkDigit === 0) || remainder === checkDigit;
+  return remainder !== null && remainder === checkDigit;
 };
 
 const isValidDate = (kt: string): boolean => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -6,7 +6,7 @@ import {
   isValid,
   isTemporary,
   sanitize,
-  formatKennitala,
+  format,
   generatePerson,
   generateTemporary,
   info,
@@ -47,8 +47,8 @@ describe("kennitala", () => {
 
   describe("formatKennitala", () => {
     it("should add dash to kennitala", () => {
-      expect(formatKennitala("1504842359")).toBe("150484-2359");
-      expect(formatKennitala("0101842359")).toBe("010184-2359");
+      expect(format("1504842359")).toBe("150484-2359");
+      expect(format("0101842359")).toBe("010184-2359");
     });
   });
 
@@ -203,7 +203,7 @@ describe("kennitala", () => {
 
   describe("formatKennitala", () => {
     it("should format kennitala correctly", () => {
-      expect(formatKennitala("3108962099")).toBe("310896-2099");
+      expect(format("3108962099")).toBe("310896-2099");
     });
   });
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -204,6 +204,8 @@ describe("kennitala", () => {
   describe("formatKennitala", () => {
     it("should format kennitala correctly", () => {
       expect(format("3108962099")).toBe("310896-2099");
+      expect(format("3108962")).toBe("310896-2");
+      expect(format("310896")).toBe("310896");
     });
   });
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,10 +1,10 @@
 // tests/index.test.ts
 
 import {
-  isPersonKennitala,
-  isCompanyKennitala,
+  isPerson,
+  isCompany,
   isValid,
-  isTemporaryKennitala,
+  isTemporary,
   sanitize,
   formatKennitala,
   generatePerson,
@@ -13,17 +13,15 @@ import {
 } from "../src/index";
 
 describe("kennitala", () => {
-  describe("isCompanyKennitala", () => {
+  describe("isCompany", () => {
     it("should be able to check if kennitala is of a company", () => {
-      expect(isCompanyKennitala("5811131290")).toBe(true);
-      expect(isCompanyKennitala("150484-2359drop table('secretTable')")).toBe(
-        false
-      );
-      expect(isCompanyKennitala("1234567890")).toBe(false);
+      expect(isCompany("5811131290")).toBe(true);
+      expect(isCompany("150484-2359drop table('secretTable')")).toBe(false);
+      expect(isCompany("1234567890")).toBe(false);
     });
 
     it("should not validate kerfiskennitölur as company kennitala", () => {
-      expect(isCompanyKennitala(generateTemporary())).toBe(false);
+      expect(isCompany(generateTemporary())).toBe(false);
     });
   });
 
@@ -83,7 +81,7 @@ describe("kennitala", () => {
     });
 
     it("should handle age calculation for children younger than 1 year", () => {
-      const kt = generatePerson(new Date(), 20);
+      const kt = generatePerson(new Date());
       const ktInfo = info(kt!);
       expect(ktInfo?.valid).toBe(true);
       expect(ktInfo?.age).toBe(0);
@@ -92,7 +90,7 @@ describe("kennitala", () => {
 
   describe("generatePerson", () => {
     it("should generate a known kennitala", () => {
-      const generatedKt = generatePerson(new Date("1996-08-31"), 20);
+      const generatedKt = generatePerson(new Date("1996-08-31"));
       expect(generatedKt).toBe("3108962099");
     });
 
@@ -104,14 +102,14 @@ describe("kennitala", () => {
         { date: new Date(1972, 11, 31), kt: "3112722099" },
       ];
       testCases.forEach(({ date, kt }) => {
-        const generatedKt = generatePerson(date, 20);
+        const generatedKt = generatePerson(date);
         expect(isValid(generatedKt!)).toBe(true);
         expect(generatedKt).toBe(kt);
       });
     });
 
     it("should generate a valid kennitala when no date is provided", () => {
-      const kt = generatePerson(new Date(1954, 1, 2), 20);
+      const kt = generatePerson(new Date(1954, 1, 2));
       expect(isValid(kt!)).toBe(true);
     });
   });
@@ -125,7 +123,7 @@ describe("kennitala", () => {
       expect(ktInfo2?.valid).toBe(true);
       expect(ktInfo2?.birthday?.toISOString().split("T")[0]).toBe("1984-04-15");
 
-      const ktInfo3 = info(generatePerson(new Date(2012, 1, 29), 20) || "");
+      const ktInfo3 = info(generatePerson(new Date(2012, 1, 29)) || "");
       expect(ktInfo3?.valid).toBe(true);
       expect(ktInfo3?.birthday?.toISOString().split("T")[0]).toBe("2012-02-29");
 
@@ -150,44 +148,44 @@ describe("kennitala", () => {
     });
   });
 
-  describe("isPersonKennitala", () => {
+  describe("isPerson", () => {
     it("should validate known valid personal kennitala of various formats", () => {
-      expect(isPersonKennitala("3108962099")).toBe(true);
-      expect(isPersonKennitala("310896-2099")).toBe(true);
-      expect(isPersonKennitala("31089daa62099")).toBe(false);
+      expect(isPerson("3108962099")).toBe(true);
+      expect(isPerson("310896-2099")).toBe(true);
+      expect(isPerson("31089daa62099")).toBe(false);
     });
 
     it("should not validate company kennitala or invalid ones", () => {
-      expect(isPersonKennitala("6010100890")).toBe(false);
-      expect(isPersonKennitala("9908962099")).toBe(false);
+      expect(isPerson("6010100890")).toBe(false);
+      expect(isPerson("9908962099")).toBe(false);
     });
 
     it("should not validate kennitala with invalid month", () => {
-      expect(isPersonKennitala("1337991337")).toBe(false);
+      expect(isPerson("1337991337")).toBe(false);
     });
   });
 
-  describe("isCompanyKennitala", () => {
+  describe("isCompany", () => {
     it("should validate known valid company ids", () => {
-      expect(isCompanyKennitala("6010100890")).toBe(true);
-      expect(isCompanyKennitala("601010-0890")).toBe(true);
+      expect(isCompany("6010100890")).toBe(true);
+      expect(isCompany("601010-0890")).toBe(true);
     });
 
     it("should not validate personal kennitala", () => {
-      expect(isCompanyKennitala("3108962099")).toBe(false);
+      expect(isCompany("3108962099")).toBe(false);
     });
   });
 
-  describe("isTemporaryKennitala", () => {
+  describe("isTemporary", () => {
     it("should validate temporary ids", () => {
-      expect(isTemporaryKennitala("8241251291")).toBe(true);
-      expect(isTemporaryKennitala("902412-2041")).toBe(true);
+      expect(isTemporary("8241251291")).toBe(true);
+      expect(isTemporary("902412-2041")).toBe(true);
       expect(isValid("8241251291")).toBe(true);
       expect(isValid("902412-2041")).toBe(true);
     });
 
     it("should not validate invalid ids", () => {
-      expect(isTemporaryKennitala("0925120590")).toBe(false);
+      expect(isTemporary("0925120590")).toBe(false);
     });
   });
 
@@ -211,12 +209,8 @@ describe("kennitala", () => {
 
   describe("Test Dataset People", () => {
     it("should validate test people when allowed", () => {
-      expect(isPersonKennitala("1908991529", { allowTestDataset: false })).toBe(
-        false
-      );
-      expect(isPersonKennitala("1909021450", { allowTestDataset: true })).toBe(
-        true
-      );
+      expect(isPerson("1908991529", { allowTestDataset: false })).toBe(false);
+      expect(isPerson("1909021450", { allowTestDataset: true })).toBe(true);
       expect(isValid("1905641429", { allowTestDataset: true })).toBe(true);
     });
   });
@@ -241,7 +235,7 @@ describe("kennitala", () => {
 
   describe("Leap Year Edge Cases", () => {
     it("should validate kennitala on February 29th of a leap year", () => {
-      const kt = generatePerson(new Date(Date.UTC(2000, 1, 29)), 20);
+      const kt = generatePerson(new Date(Date.UTC(2000, 1, 29)));
       expect(kt).toBeDefined();
       expect(isValid(kt!)).toBe(true);
       const ktInfo = info(kt!);
@@ -256,7 +250,7 @@ describe("kennitala", () => {
       const birthDate = new Date(
         Date.UTC(birthYear, today.getUTCMonth(), today.getUTCDate() - 1)
       );
-      const kt = generatePerson(birthDate, 20);
+      const kt = generatePerson(birthDate);
       const ktInfo = info(kt!);
       expect(Math.floor(ktInfo!.age!)).toBe(30);
     });
@@ -267,7 +261,7 @@ describe("kennitala", () => {
       const birthDate = new Date(
         Date.UTC(birthYear, today.getUTCMonth(), today.getUTCDate())
       );
-      const kt = generatePerson(birthDate, 20);
+      const kt = generatePerson(birthDate);
       const ktInfo = info(kt!);
       expect(Math.floor(ktInfo!.age!)).toBe(30);
     });
@@ -278,7 +272,7 @@ describe("kennitala", () => {
       const birthDate = new Date(
         Date.UTC(birthYear, today.getUTCMonth(), today.getUTCDate() + 1)
       );
-      const kt = generatePerson(birthDate, 20);
+      const kt = generatePerson(birthDate);
       const ktInfo = info(kt!);
       expect(Math.floor(ktInfo!.age!)).toBe(29);
     });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -103,8 +103,8 @@ describe("kennitala", () => {
       ];
       testCases.forEach(({ date, kt }) => {
         const generatedKt = generatePerson(date);
-        expect(isValid(generatedKt!)).toBe(true);
         expect(generatedKt).toBe(kt);
+        expect(isValid(generatedKt!)).toBe(true);
       });
     });
 


### PR DESCRIPTION
Related to #35 and another request from @eirikurn to change the API so it is more compatible with V1.

For example `isPerson` instead of `isPersonkennitala`. This reverts back to `isPerson` which is how it was in V1.

I also updated test cases where I added 20 as the starting increment for `generatePerson`. The manual addition of the starting increment in the tests caused me to miss that `generatePerson` sometimes generated ID's with starting increments below 20. I fixed this by making the default starting increments for persons `20`.

I also removed the undefined returns from the `info` function where an undefined century digit at the end of a kt would return undefined. I refactored the function so it now always returns a `KennitalaInfo` object.

Also updated the `formatKennitala` function so it returns a string like before. It adds a optional spacer between the 6th and 7th digits in case the string length is longer than 5. Useful for formatting input fields.