### PR TITLE
fix: Improve cjs compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kennitala",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kennitala",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kennitala",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Icelandic social security number (kennitölur) utilities for servers and clients",
   "author": "Hermann Björgvin Haraldsson <hermann@hermann.is>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "type": "git",
     "url": "https://github.com/HermannBjorgvin/Kennitala.git"
   },
-  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
TypeScript was still complaining about importing this module in cjs mode since it explicitly sets `type: 'module'`.

According to [this article](https://dev.to/snyk/building-an-npm-package-compatible-with-esm-and-cjs-in-2024-88m), "type" should be avoided. Enough to list the available files.

Added the old package.json fields like in the article for maximum compatibility. Seems to fix the issue for island.is.