### PR TITLE
feat: Misc change suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ interface KennitalaInfo {
 }
 ```
 
-#### `generatePerson(date: Date): string | undefined`
+#### `generatePerson(date: Date): string`
 
 Generates a valid kennitala for a person based on a `Date` object to specify the birth date.
 
@@ -176,9 +176,9 @@ Generates a valid kennitala for a person based on a `Date` object to specify the
 
   - `date`: The birth date to use for generating the kennitala.
 
-- **Returns:** A valid kennitala string if generation is successful, `undefined` otherwise.
+- **Returns:** A valid kennitala string.
 
-#### `generateCompany(date: Date): string | undefined`
+#### `generateCompany(date: Date): string`
 
 Generates a valid kennitala for a company based on a `Date` object to specify the registration date.
 
@@ -186,7 +186,7 @@ Generates a valid kennitala for a company based on a `Date` object to specify th
 
   - `date`: The date to use for generating the company kennitala.
 
-- **Returns:** A valid kennitala string if generation is successful, `undefined` otherwise.
+- **Returns:** A valid kennitala string.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Checks if the kennitala is a valid temporary ID.
 
 - **Returns:** `true` if the kennitala is a valid temporary ID, `false` otherwise.
 
-#### `sanitize(kennitala: string): string | undefined`
+#### `sanitize(kennitala: string): string`
 
 Sanitizes the input by removing all non-digit characters.
 
@@ -132,7 +132,7 @@ Sanitizes the input by removing all non-digit characters.
 
   - `kennitala`: The kennitala string to sanitize.
 
-- **Returns:** The sanitized kennitala string if input is valid, `undefined` otherwise.
+- **Returns:** The sanitized kennitala string if input is valid, otherwise returns the `kennitala` string unchanged.
 
 #### `formatKennitala(kennitala: string, spacer?: boolean): string`
 

--- a/README.md
+++ b/README.md
@@ -168,13 +168,14 @@ interface KennitalaInfo {
 }
 ```
 
-#### `generatePerson(date: Date): string`
+#### `generatePerson(date: Date, startingIncrement = 20): string`
 
 Generates a valid kennitala for a person based on a `Date` object to specify the birth date.
 
 - **Parameters:**
 
   - `date`: The birth date to use for generating the kennitala.
+  - `startingIncrement`: The starting increment for digits 7 and 8 (default: 20).
 
 - **Returns:** A valid kennitala string.
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
       "require": "./dist/index.cjs"
     }
   },
+  "sideEffects": false,
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kennitala",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Icelandic social security number (kennitölur) utilities for servers and clients",
   "author": "Hermann Björgvin Haraldsson <hermann@hermann.is>",
   "license": "MIT",

--- a/src/generation.ts
+++ b/src/generation.ts
@@ -6,7 +6,7 @@ const generateKennitala = (
   date: Date,
   entityFn: (day: number) => number,
   startingIncrement?: number
-): string | undefined => {
+): string => {
   let day = date.getUTCDate();
   day = entityFn(day);
 
@@ -56,8 +56,8 @@ const generateKennitala = (
   let digits789: string | undefined;
   if (startingIncrement) {
     digits789 = incrementingChecksum(kt, startingIncrement);
-    if (!digits789) return undefined;
-  } else {
+  }
+  if (!digits789) {
     digits789 = randomAndChecksum(kt);
   }
 
@@ -71,12 +71,11 @@ const generateKennitala = (
 
 const generatePerson = (
   date: Date,
-  startingIncrement = 20
-): string | undefined => {
-  return generateKennitala(date, personDayDelta, startingIncrement);
+): string => {
+  return generateKennitala(date, personDayDelta, 20);
 };
 
-const generateCompany = (date: Date): string | undefined => {
+const generateCompany = (date: Date): string => {
   return generateKennitala(date, companyDayDelta);
 };
 

--- a/src/generation.ts
+++ b/src/generation.ts
@@ -56,8 +56,8 @@ const generateKennitala = (
   let digits789: string | undefined;
   if (startingIncrement) {
     digits789 = incrementingChecksum(kt, startingIncrement);
-  }
-  if (!digits789) {
+    if (!digits789) return '';
+  } else {
     digits789 = randomAndChecksum(kt);
   }
 
@@ -71,8 +71,9 @@ const generateKennitala = (
 
 const generatePerson = (
   date: Date,
+  startingIncrement = 20,
 ): string => {
-  return generateKennitala(date, personDayDelta, 20);
+  return generateKennitala(date, personDayDelta, startingIncrement);
 };
 
 const generateCompany = (date: Date): string => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,8 +68,8 @@ export const isTemporary = (kennitala: string): boolean => {
   return kt ? isTemporaryType(kt) : false;
 };
 
-export const sanitize = (kennitala: string): string | undefined =>
-  sanitizeInput(kennitala);
+export const sanitize = (kennitala: string): string =>
+  sanitizeInput(kennitala) ?? kennitala;
 
 export const format = (kennitala: string, spacer: boolean = true): string => {
   const kt = kennitala.replace(/\D+/g, "");

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,3 +154,16 @@ export const info = (
 };
 
 export { generatePerson, generateCompany, generateTemporary };
+
+export default {
+  isValid,
+  isPerson,
+  isCompany,
+  isTemporary,
+  sanitize,
+  format,
+  info,
+  generatePerson,
+  generateCompany,
+  generateTemporary,
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,6 +154,7 @@ export const info = (
 };
 
 export { generatePerson, generateCompany, generateTemporary };
+export type { KennitalaInfo, ValidationOptions };
 
 export default {
   isValid,

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export const isTemporary = (kennitala: string): boolean => {
 };
 
 export const sanitize = (kennitala: string): string =>
-  sanitizeInput(kennitala) ?? kennitala;
+  sanitizeInput(kennitala) ?? '';
 
 export const format = (kennitala: string, spacer: boolean = true): string => {
   const kt = kennitala.replace(/\D+/g, "");

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -41,7 +41,7 @@ describe("kennitala", () => {
     it("should clean kennitala by removing non-digit characters", () => {
       expect(sanitize("010159-1234")).toBe("0101591234");
       expect(sanitize("1234567890")).toBe("1234567890");
-      expect(sanitize(1234567890 as unknown as string)).toBeUndefined();
+      expect(sanitize(1234567890 as unknown as string)).toBe('');
     });
   });
 
@@ -190,14 +190,14 @@ describe("kennitala", () => {
   });
 
   describe("sanitize", () => {
-    it("should return undefined for invalid formats", () => {
-      expect(sanitize("310896DIRTYSSID2099")).toBeUndefined();
-      expect(sanitize("6010sfa100890")).toBeUndefined();
+    it("should return empty string for invalid formats", () => {
+      expect(sanitize("310896DIRTYSSID2099")).toBe('');
+      expect(sanitize("6010sfa100890")).toBe('');
     });
 
-    it("should return undefined for non-string types", () => {
+    it("should return empty string for non-string types", () => {
       // @ts-expect-error Testing invalid input
-      expect(sanitize(3108962099)).toBeUndefined();
+      expect(sanitize(3108962099)).toBe('');
     });
   });
 
@@ -287,12 +287,12 @@ describe("kennitala", () => {
     });
 
     it("should reject invalid formats", () => {
-      expect(sanitize("310896209")).toBeUndefined(); // Too short
-      expect(sanitize("310896-20999")).toBeUndefined(); // Too long
-      expect(sanitize("31-0896-2099")).toBeUndefined(); // Incorrect hyphen placement
-      expect(sanitize("31a8962099")).toBeUndefined(); // Contains letters
-      expect(sanitize("3108962099 ")).toBeUndefined(); // Trailing space
-      expect(sanitize(" 3108962099")).toBeUndefined(); // Leading space
+      expect(sanitize("310896209")).toBe(''); // Too short
+      expect(sanitize("310896-20999")).toBe(''); // Too long
+      expect(sanitize("31-0896-2099")).toBe(''); // Incorrect hyphen placement
+      expect(sanitize("31a8962099")).toBe(''); // Contains letters
+      expect(sanitize("3108962099 ")).toBe(''); // Trailing space
+      expect(sanitize(" 3108962099")).toBe(''); // Leading space
     });
   });
 });


### PR DESCRIPTION
To make the upgrade on island-is smoother, I made the following changes in our fork, one per commit:

1. We can't think of having any use case for using startingIncrement in generatePerson, and it makes the types much harder to work with due to the strange error case causing the function to return undefined. The argument wasn't even documented.
2. It is handy to have the default export be a object with all functions, like lodash, especially for cjs. It also saves us from having to update almost all usage in island.is.
3. Update sanitize to always return a string, returning the original string if we can't find a kennitala, inspired by [is-kennitala](https://github.com/maranomynet/is-kennitala).
4. Export a couple of TypeScript types like KennitalaInfo.

Sorry for bundling them together in one PR. Feel free to discuss the merits of each change separately.

I guess the most controversial is the sanitise change. In our use cases, it is more handy to always get a string back, even though it is not a kennitala (that's what isValid is for). Maybe we should split the function up like in is-kennitala? A careful vs strict version of sanitize/clean.