### PR TITLE
Removed validation for test persons

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,9 @@
 import { sanitizeInput, getCentury } from "./utils";
 import {
   evaluate,
-  getDefaultOptions,
   isCompany as isCompanyType,
   isPerson as isPersonType,
   isTemporary as isTemporaryType,
-  isTestPerson as isTestPersonType,
   isValidDate,
 } from "./validation";
 import {
@@ -15,43 +13,28 @@ import {
   generateCompany,
   generateTemporary,
 } from "./generation";
-import { KennitalaInfo, ValidationOptions } from "./types";
+import { KennitalaInfo } from "./types";
 
-export const isValid = (
-  kennitala: string,
-  options?: ValidationOptions
-): boolean => {
+export const isValid = (kennitala: string): boolean => {
   const kt = sanitizeInput(kennitala);
   if (!kt) return false;
 
   if (isTemporaryType(kt)) return true;
 
-  const opts = getDefaultOptions(options);
   const person = evaluate(kt, isPersonType);
-  const testPersonResult = evaluate(kt, isTestPersonType);
   const company = evaluate(kt, isCompanyType);
   const dateValid = isValidDate(kt);
 
-  return (
-    dateValid &&
-    (person || company || (testPersonResult && opts.allowTestDataset === true))
-  );
+  return dateValid && (person || company);
 };
 
-export const isPerson = (
-  kennitala: string,
-  options?: ValidationOptions
-): boolean => {
+export const isPerson = (kennitala: string): boolean => {
   const kt = sanitizeInput(kennitala);
   if (!kt) return false;
 
   const dateValid = isValidDate(kt);
 
-  if (isTestPersonType(kt) && options?.allowTestDataset) {
-    return dateValid && evaluate(kt, isTestPersonType);
-  } else {
-    return dateValid && evaluate(kt, isPersonType);
-  }
+  return dateValid && evaluate(kt, isPersonType);
 };
 
 export const isCompany = (kennitala: string): boolean => {
@@ -77,10 +60,7 @@ export const format = (kennitala: string, spacer: boolean = true): string => {
   return `${kt.slice(0, 6)}${spacer && kt.length > 6 ? "-" : ""}${kt.slice(6)}`;
 };
 
-export const info = (
-  kennitala: string,
-  options?: ValidationOptions
-): KennitalaInfo => {
+export const info = (kennitala: string): KennitalaInfo => {
   const kt = sanitizeInput(kennitala);
   if (!kt) {
     return {
@@ -104,7 +84,7 @@ export const info = (
     };
   }
 
-  if (isPerson(kt, options) || isCompany(kt)) {
+  if (isPerson(kt) || isCompany(kt)) {
     let day = parseInt(kt.substring(0, 2), 10);
     if (day > 40) {
       day -= 40;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,3 @@ export interface KennitalaInfo {
   birthdayReadable: string;
   age: number;
 }
-
-export interface ValidationOptions {
-  allowTestDataset?: boolean;
-}

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,7 +1,6 @@
 // src/validation.ts
 
 import { calculateChecksumRemainder, getCentury } from "./utils";
-import { ValidationOptions } from "./types";
 
 const evaluate = (
   kt: string,
@@ -52,16 +51,8 @@ const isValidDate = (kt: string): boolean => {
 
 const isPerson = (kt: string): boolean => {
   const day = parseInt(kt.substring(0, 2), 10);
-  const digits78 = parseInt(kt.substring(6, 8), 10);
 
-  return day > 0 && day <= 31 && digits78 >= 20;
-};
-
-const isTestPerson = (kt: string): boolean => {
-  const day = parseInt(kt.substring(0, 2), 10);
-  const digits78 = kt.substring(6, 8);
-
-  return day > 0 && day <= 31 && (digits78 === "14" || digits78 === "15");
+  return day > 0 && day <= 31;
 };
 
 const isCompany = (kt: string): boolean => {
@@ -73,18 +64,4 @@ const isCompany = (kt: string): boolean => {
 const isTemporary = (kt: string): boolean =>
   kt.startsWith("8") || kt.startsWith("9");
 
-const getDefaultOptions = (options?: ValidationOptions): ValidationOptions => {
-  return {
-    allowTestDataset: !!options && options.allowTestDataset === true,
-  };
-};
-
-export {
-  evaluate,
-  getDefaultOptions,
-  isCompany,
-  isPerson,
-  isTemporary,
-  isTestPerson,
-  isValidDate,
-};
+export { evaluate, isCompany, isPerson, isTemporary, isValidDate };

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -209,16 +209,22 @@ describe("kennitala", () => {
     });
   });
 
-  describe("KT with 7th digits 1 and 0 sould pass", () => {
+  describe("KT with 7th digits 1 and 0 should pass", () => {
     it("should validate test people when allowed", () => {
-      for (let i = 0; i < 1000; i++) {
+      for (let i = 0; i < 10000; i++) {
         // generate kt with random date from 1800-2100 and validate it
+        const start = new Date(1860, 0, 1).getTime();
+        const end = new Date(2030, 11, 31).getTime();
+        const randomDate = start + Math.random() * (end - start);
+
         const kt = generatePerson(
-          new Date(Date.UTC(1800 + Math.floor(Math.random() * 300), 0, 1)),
-          Math.floor(Math.random() * 30)
+          new Date(randomDate),
+          Math.floor(Math.random() * 99)
         );
 
-        expect(isPerson(kt!)).toBe(true);
+        if (kt) {
+          expect(isPerson(kt!)).toBe(true);
+        }
       }
 
       expect(isPerson("1908990129")).toBe(true);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -209,11 +209,22 @@ describe("kennitala", () => {
     });
   });
 
-  describe("Test Dataset People", () => {
+  describe("KT with 7th digits 1 and 0 sould pass", () => {
     it("should validate test people when allowed", () => {
-      expect(isPerson("1908991529", { allowTestDataset: false })).toBe(false);
-      expect(isPerson("1909021450", { allowTestDataset: true })).toBe(true);
-      expect(isValid("1905641429", { allowTestDataset: true })).toBe(true);
+      for (let i = 0; i < 1000; i++) {
+        // generate kt with random date from 1800-2100 and validate it
+        const kt = generatePerson(
+          new Date(Date.UTC(1800 + Math.floor(Math.random() * 300), 0, 1)),
+          Math.floor(Math.random() * 30)
+        );
+
+        expect(isPerson(kt!)).toBe(true);
+      }
+
+      expect(isPerson("1908990129")).toBe(true);
+      expect(isPerson("1908991529")).toBe(true);
+      expect(isPerson("1909021450")).toBe(true);
+      expect(isValid("1905641429")).toBe(true);
     });
   });
 


### PR DESCRIPTION
Since real persons with 0 or 1 as 7th char exist as edge cases I am removing validation for test persons.

And since the person with a KT like that can be valid then test persons will also always be valid, so no need to add an option to allow the test dataset